### PR TITLE
Allow local use without module CORS errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+

--- a/index.html
+++ b/index.html
@@ -133,6 +133,11 @@
 
     <div class="toast" id="toast"></div>
 
-    <script type="module" src="js/app.js"></script>
-</body>
-</html>
+    <script src="js/utils/helpers.js"></script>
+    <script src="js/utils/storage.js"></script>
+    <script src="js/services/DataProcessor.js"></script>
+    <script src="js/components/ClientCard.js"></script>
+    <script src="js/components/DataTable.js"></script>
+    <script src="js/app.js"></script>
+  </body>
+  </html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,8 +1,3 @@
-import { Helpers } from './utils/helpers.js';
-import { StorageManager } from './utils/storage.js';
-import { ClientCard } from './components/ClientCard.js';
-import { DataTable } from './components/DataTable.js';
-import { DataProcessor } from './services/DataProcessor.js';
 
 class LeadDialer {
     constructor() {
@@ -116,27 +111,24 @@ class LeadDialer {
 
     async handleFileUpload(file) {
         if (!file || !file.name.endsWith('.json')) {
-            Help
-        async handleFileUpload(file) {
-            if (!file || !file.name.endsWith('.json')) {
-                Helpers.showToast('Please select a valid JSON file', 'error');
-                return;
-            }
-
-            try {
-                const text = await file.text();
-                const data = JSON.parse(text);
-                
-                if (!Array.isArray(data)) {
-                    throw new Error('JSON must be an array of objects');
-                }
-
-                this.processImportedData(data);
-                Helpers.showToast(`Successfully imported ${data.length} records`);
-            } catch (error) {
-                Helpers.showToast('Error parsing JSON file: ' + error.message, 'error');
-            }
+            Helpers.showToast('Please select a valid JSON file', 'error');
+            return;
         }
+
+        try {
+            const text = await file.text();
+            const data = JSON.parse(text);
+
+            if (!Array.isArray(data)) {
+                throw new Error('JSON must be an array of objects');
+            }
+
+            this.processImportedData(data);
+            Helpers.showToast(`Successfully imported ${data.length} records`);
+        } catch (error) {
+            Helpers.showToast('Error parsing JSON file: ' + error.message, 'error');
+        }
+    }
 
         processImportedData(data) {
             this.clients = DataProcessor.processImportedData(data, this.phoneDuplicates);
@@ -304,4 +296,3 @@ class LeadDialer {
     // Initialize the application
     const app = new LeadDialer();
     window.app = app;
-</script>

--- a/js/components/ClientCard.js
+++ b/js/components/ClientCard.js
@@ -1,6 +1,4 @@
-import { Helpers } from '../utils/helpers.js';
-
-export class ClientCard {
+class ClientCard {
     constructor(app) {
         this.app = app;
         this.element = document.getElementById('clientCard');

--- a/js/components/DataTable.js
+++ b/js/components/DataTable.js
@@ -1,6 +1,4 @@
-import { Helpers } from '../utils/helpers.js';
-
-export class DataTable {
+class DataTable {
     constructor(app) {
         this.app = app;
         this.tbody = document.getElementById('clientsTableBody');

--- a/js/services/DataProcessor.js
+++ b/js/services/DataProcessor.js
@@ -1,4 +1,4 @@
-export class DataProcessor {
+class DataProcessor {
     static processImportedData(data, phoneDuplicates) {
         return data.map((item, index) => {
             const city = this.extractCity(item);

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -1,4 +1,4 @@
-export class Helpers {
+class Helpers {
     static escapeHtml(text) {
         const div = document.createElement('div');
         div.textContent = text;

--- a/js/utils/storage.js
+++ b/js/utils/storage.js
@@ -1,4 +1,4 @@
-export class StorageManager {
+class StorageManager {
     static STORAGE_KEY = 'leadDialerData';
 
     static saveData(clients, phoneDuplicates) {


### PR DESCRIPTION
## Summary
- Load all scripts directly in index.html so the page works over the `file://` protocol without CORS
- Remove ES module imports/exports and fix duplicated `handleFileUpload` logic
## Testing
- ⚠️ `npm test` (missing script)
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b997f5f2788324ab2c1a3ad6f4087a