### PR TITLE
Allow local use without module CORS errors and add Docker deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+dist
+.git

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # CallHTML
-call page
+
+Simple lead dialer & filter application.
+
+## Running locally
+
+Open `index.html` directly in your browser.
+
+## Docker
+
+Build and run the container to serve the app with Nginx:
+
+```sh
+docker build -t callhtml .
+docker run -p 8080:80 callhtml
+```
+
+Then visit [http://localhost:8080](http://localhost:8080) in your browser.

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
                         <div class="drop-zone-icon">📂</div>
                         <p>Drop JSON file here or click to browse</p>
                     </div>
+                    <button class="btn btn-danger" id="clearDataBtn">🗑️ Clear All Data</button>
                 </div>
             </div>
 
@@ -133,6 +134,11 @@
 
     <div class="toast" id="toast"></div>
 
-    <script type="module" src="js/app.js"></script>
-</body>
-</html>
+    <script src="js/utils/helpers.js"></script>
+    <script src="js/utils/storage.js"></script>
+    <script src="js/services/DataProcessor.js"></script>
+    <script src="js/components/ClientCard.js"></script>
+    <script src="js/components/DataTable.js"></script>
+    <script src="js/app.js"></script>
+  </body>
+  </html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,8 +1,3 @@
-import { Helpers } from './utils/helpers.js';
-import { StorageManager } from './utils/storage.js';
-import { ClientCard } from './components/ClientCard.js';
-import { DataTable } from './components/DataTable.js';
-import { DataProcessor } from './services/DataProcessor.js';
 
 class LeadDialer {
     constructor() {
@@ -85,6 +80,13 @@ class LeadDialer {
         document.getElementById('exportLeadsCSV').addEventListener('click', () => this.exportData('leads', 'csv'));
         document.getElementById('exportLeadsJSON').addEventListener('click', () => this.exportData('leads', 'json'));
 
+        // Clear data
+        document.getElementById('clearDataBtn').addEventListener('click', () => {
+            if (confirm('Clear all stored data?')) {
+                this.clearAllData();
+            }
+        });
+
         // Keyboard shortcuts
         document.addEventListener('keydown', (e) => {
             if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
@@ -116,27 +118,24 @@ class LeadDialer {
 
     async handleFileUpload(file) {
         if (!file || !file.name.endsWith('.json')) {
-            Help
-        async handleFileUpload(file) {
-            if (!file || !file.name.endsWith('.json')) {
-                Helpers.showToast('Please select a valid JSON file', 'error');
-                return;
-            }
-
-            try {
-                const text = await file.text();
-                const data = JSON.parse(text);
-                
-                if (!Array.isArray(data)) {
-                    throw new Error('JSON must be an array of objects');
-                }
-
-                this.processImportedData(data);
-                Helpers.showToast(`Successfully imported ${data.length} records`);
-            } catch (error) {
-                Helpers.showToast('Error parsing JSON file: ' + error.message, 'error');
-            }
+            Helpers.showToast('Please select a valid JSON file', 'error');
+            return;
         }
+
+        try {
+            const text = await file.text();
+            const data = JSON.parse(text);
+
+            if (!Array.isArray(data)) {
+                throw new Error('JSON must be an array of objects');
+            }
+
+            this.processImportedData(data);
+            Helpers.showToast(`Successfully imported ${data.length} records`);
+        } catch (error) {
+            Helpers.showToast('Error parsing JSON file: ' + error.message, 'error');
+        }
+    }
 
         processImportedData(data) {
             this.clients = DataProcessor.processImportedData(data, this.phoneDuplicates);
@@ -258,6 +257,34 @@ class LeadDialer {
             }
         }
 
+        copyPhone() {
+            if (this.filteredClients.length === 0) return;
+            const client = this.filteredClients[this.currentClientIndex];
+            if (client.phone) {
+                Helpers.copyToClipboard(client.phone);
+            }
+        }
+
+        clearAllData() {
+            StorageManager.clearData();
+            this.clients = [];
+            this.filteredClients = [];
+            this.phoneDuplicates = new Map();
+            this.currentFilter = 'all';
+            this.currentSearch = '';
+            this.currentPage = 1;
+            this.currentClientIndex = 0;
+
+            document.getElementById('searchInput').value = '';
+            document.querySelectorAll('.chip').forEach(c => c.classList.remove('active'));
+            document.querySelector('.chip[data-filter="all"]').classList.add('active');
+
+            this.clientCard.clear();
+            this.dataTable.clear();
+            this.updateStats();
+            Helpers.showToast('All data cleared');
+        }
+
         exportData(type, format) {
             let dataToExport;
             
@@ -304,4 +331,3 @@ class LeadDialer {
     // Initialize the application
     const app = new LeadDialer();
     window.app = app;
-</script>

--- a/js/components/ClientCard.js
+++ b/js/components/ClientCard.js
@@ -1,6 +1,4 @@
-import { Helpers } from '../utils/helpers.js';
-
-export class ClientCard {
+class ClientCard {
     constructor(app) {
         this.app = app;
         this.element = document.getElementById('clientCard');
@@ -15,7 +13,9 @@ export class ClientCard {
         this.element.innerHTML = `
             <div class="client-info">
                 <div class="phone-number">
-                    ${client.phone ? client.phone : '<span class="no-phone">No phone number</span>'}
+                    ${client.phone
+                        ? `${Helpers.escapeHtml(client.phone)} <button class="btn btn-outline copy-phone-btn" onclick="app.copyPhone()">Copy</button>`
+                        : '<span class="no-phone">No phone number</span>'}
                     ${isDuplicate ? '<span class="duplicate-warning">Duplicate</span>' : ''}
                 </div>
                 <div class="client-name">${Helpers.escapeHtml(client.name)}</div>

--- a/js/components/DataTable.js
+++ b/js/components/DataTable.js
@@ -1,6 +1,4 @@
-import { Helpers } from '../utils/helpers.js';
-
-export class DataTable {
+class DataTable {
     constructor(app) {
         this.app = app;
         this.tbody = document.getElementById('clientsTableBody');

--- a/js/services/DataProcessor.js
+++ b/js/services/DataProcessor.js
@@ -1,4 +1,4 @@
-export class DataProcessor {
+class DataProcessor {
     static processImportedData(data, phoneDuplicates) {
         return data.map((item, index) => {
             const city = this.extractCity(item);

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -1,4 +1,4 @@
-export class Helpers {
+class Helpers {
     static escapeHtml(text) {
         const div = document.createElement('div');
         div.textContent = text;
@@ -47,5 +47,19 @@ export class Helpers {
         setTimeout(() => {
             toast.classList.remove('show');
         }, 3000);
+    }
+
+    static async copyToClipboard(text) {
+        try {
+            await navigator.clipboard.writeText(text);
+        } catch (err) {
+            const textarea = document.createElement('textarea');
+            textarea.value = text;
+            document.body.appendChild(textarea);
+            textarea.select();
+            document.execCommand('copy');
+            document.body.removeChild(textarea);
+        }
+        this.showToast('Phone number copied');
     }
 }

--- a/js/utils/storage.js
+++ b/js/utils/storage.js
@@ -1,4 +1,4 @@
-export class StorageManager {
+class StorageManager {
     static STORAGE_KEY = 'leadDialerData';
 
     static saveData(clients, phoneDuplicates) {

--- a/styles/main.css
+++ b/styles/main.css
@@ -281,6 +281,12 @@ body {
     word-break: break-all;
 }
 
+.copy-phone-btn {
+    padding: 4px 8px;
+    font-size: 12px;
+    margin-left: 8px;
+}
+
 .no-phone {
     font-size: 24px;
     color: var(--gray-400);


### PR DESCRIPTION
## Summary
- Load all scripts directly in index.html so the page works over the `file://` protocol without CORS
- Remove ES module imports/exports and fix duplicated `handleFileUpload` logic
- Add a header control to clear all stored lead data
- Add a copy-to-clipboard button next to each client's phone number
- Add a Dockerfile and accompanying `.dockerignore` so the site can be served from a container

## Testing
- ⚠️ `npm test` (missing script)
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b997f5f2788324ab2c1a3ad6f4087a